### PR TITLE
[BUGFIX] Prevent browser from redirecting

### DIFF
--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -43,6 +43,8 @@ export class Dropdown {
 			//console.log($(evt.currentTarget));
 			let item:any = $(evt.currentTarget).data('item');
 			this.itemSelectedLaunchEvent(item);
+			
+			return false; //prevent browser from redirecting to #
 		});
 		
 		this._dd.on('keyup', (evt:JQueryEventObject) => {


### PR DESCRIPTION
On item select, the browser tries to redirect to the href="#" from the clicked a tag. This can lead to misredirects