### PR TITLE
Fix invalid markup generated for dropdown in Bootstrap 4

### DIFF
--- a/src/dropdownV4.ts
+++ b/src/dropdownV4.ts
@@ -209,6 +209,7 @@ export class DropdownV4 {
 
         const li = $('<a >');
         li.addClass('dropdown-item')
+          .attr('href', 'javascript:void(0)')
           .css({ 'overflow': 'hidden', 'text-overflow': 'ellipsis' })
           .html(itemHtml)
           .data('item', item);


### PR DESCRIPTION
When run in Bootstrap 4, the plugin creates `<a>` elements for the dropdown. However, this is invalid markup, as the `href` attribute is required for the `<a>` element.

The result of this omission is that the text color is incorrect in many themes and the cursor is not a pointer:

![2021-01-04 22_59_51-Pearup — Options](https://user-images.githubusercontent.com/1253444/103616312-06957b80-4ee1-11eb-9c45-be9ca185dd67.png)

This pull request fixes the oversight.