### PR TITLE
BUG FIX: searchpre + empty string failure

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -365,7 +365,8 @@ export class AutoComplete {
     // custom handler may change newValue
     if (this._settings.events.searchPre !== null) {
       const newValue: string = this._settings.events.searchPre(this._searchText, this._$el);
-      if (!newValue)
+      // only punt if we explicitely request it, otherwise allow search for ''
+      if (newValue === false)
         return;
       this._searchText = newValue;
     }


### PR DESCRIPTION
A bug exists currently where users can no longer search for an empty string ('') when searchPre is implemented.
Need to explicitly compare the searchPre return to false instead of trusting the ! operator on the string itself as sometimes '' is desired.